### PR TITLE
Retry trigger with custom HTTP status code and Retry with delay support

### DIFF
--- a/Documentation/HTTPClient.md
+++ b/Documentation/HTTPClient.md
@@ -162,6 +162,10 @@ By default each client has a single validator called `HTTPDefaultValidator`; thi
 - If it's not a recoverable error the call fail with that error.
 - If no error has occurred call is okay and move on to the next validator (if any) or resolve the request.
 
+`HTTPDefaultValidator` exposes the following configurable properties:  
+- `allowsEmptyResponses`:  If `true` empty responses are tracked as valid responses if status code it's not an error.  In case of empty response validation fails with `emptyResponse` error.
+- `retriableHTTPStatusCodes`: defines a list of `HTTPStatusCode` which can trigger a retry of the call (when request's `maxRetries` > 1). This is a dictionary so you need to also specify the `TimeInterval` as seconds before retry the request (`0` means immediately, other positive values are expressed in seconds).
+
 **Empty Responses**
 
 `HTTPDefaultValidator` also allows to deal with empty responses; by setting the `.allowsEmptyResponses` property you can decide to mark an empty response received from server as okay or as an error. By default no empty response are allowed.

--- a/Sources/RealHTTP/Response/Validators/HTTPDefaultValidator.swift
+++ b/Sources/RealHTTP/Response/Validators/HTTPDefaultValidator.swift
@@ -35,6 +35,13 @@ open class HTTPDefaultValidator: HTTPResponseValidatorProtocol {
         .tooManyRequests: 3 // wait 3 seconds before retry the call.
     ]
     
+    // MARK: - Initialization
+    
+    /// Initialize a new validator.
+    public init() {
+    
+    }
+    
     // MARK: - Validation
     
     /// Validate the response and set the action to perform.

--- a/Sources/RealHTTP/Response/Validators/HTTPResponseValidatorProtocol.swift
+++ b/Sources/RealHTTP/Response/Validators/HTTPResponseValidatorProtocol.swift
@@ -18,6 +18,7 @@ import Foundation
 /// - `failWithError`: call fails with given error.
 /// - `retryIfPossible`: retry the call; this action may be ignored if source HTTPRequest does not allows retry or
 ///                      the maximum amount of retries has been reached yet.
+/// - `retryWithInterval`: retry the call after a given specified time interval (in seconds)
 /// - `retryAfter`: attempt to execute another request, then the current one
 ///                 (ie. session is expired and a silent login must be accomplished
 ///                 before re-trying the current request).
@@ -25,6 +26,7 @@ import Foundation
 public enum HTTPResponseValidatorResult {
     case failWithError(Error)
     case retryIfPossible
+    case retryWithInterval(TimeInterval)
     case retryAfter(HTTPRequestProtocol)
     case passed
 }

--- a/Tests/RealHTTPTests/IndomioHTTPTests.swift
+++ b/Tests/RealHTTPTests/IndomioHTTPTests.swift
@@ -1,5 +1,5 @@
     import XCTest
-    @testable import IndomioHTTP
+    @testable import RealHTTP
 
     final class IndomioHTTPTests: XCTestCase {
 


### PR DESCRIPTION
The following PR adds support to define custom HTTP status codes (`HTTPStatusCode`) which can trigger retry of a network request via the default validator object (`HTTPDefaultValidator`).

The class `HTTPDefaultValidator` now include the following property:
- `retriableHTTPStatusCodes`: it defines a list of `HTTPStatusCode` which can trigger a retry of the call; it's a dictionaryw where the value is a `TimeInterval` (0 means retry immediately, a positive value like 2 means 2 seconds after retry).

In its default implementation`.tooManyRequests`'s http status code with 3 seconds interval.  
However you can create or modify the default behaviour.  

This is a short example using the shared `HTTPClient.shared` instance:

```swift
let myValidator = HTTPDefaultValidator()
myValidator.retriableHTTPStatusCodes = [.tooManyRequests: 5] // wait 5 seconds for HTTP 429
HTTPClient.shared.validators = [myValidator]
        
request.maxRetries = 2 // you must set a retry > 1 in order to get it works
request.onRawResponse { response in
  // do something
}
request.run()
```
