### PR TITLE
[#6] Fix for HTTPAltRequestValidator when network error has occurred

### DIFF
--- a/Sources/RealHTTP/Response/Validators/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Response/Validators/HTTPAltRequestValidator.swift
@@ -58,7 +58,7 @@ open class HTTPAltRequestValidator: HTTPResponseValidatorProtocol {
     // MARK: - Protocol Conformance
     
     open func validate(response: HTTPRawResponse, forRequest request: HTTPRequestProtocol) -> HTTPResponseValidatorResult {
-        guard let statusCode = response.error?.statusCode, triggerHTTPCodes.contains(statusCode) else {
+        if let statusCode = response.error?.statusCode, triggerHTTPCodes.contains(statusCode) {
             return .passed
         }
         


### PR DESCRIPTION
In case of network error (status code = nil) the HTTPAltRequestValidator custom callback is not called