### PR TITLE
Reimplement HTTPAltRequestValidator

### DIFF
--- a/Documentation/3.Advanced_HTTPClient.md
+++ b/Documentation/3.Advanced_HTTPClient.md
@@ -7,6 +7,7 @@
     - [Fail with error](#fail-with-error)
     - [Retry with strategy](#retry-with-strategy)
   - [The Default Validator](#the-default-validator)
+  - [Alt Request Validator](#alt-request-validator)
   - [Custom Validators](#custom-validators)
   - [Retry After [Another] Call](#retry-after-another-call)
 
@@ -81,6 +82,38 @@ Particularly it:
 
 This validator should never be removed unless you have a really different logic to parse and validate errors.  
 Typically you may want to add a new validator after this in order to perform your own logic based upon the uniqueness of your webservice.
+
+## Alt Request Validator
+
+RealHTTP also provide a special validator called `HTTPAltRequestValidator`. This validator can be used when you need to execute a specific `HTTPRequest` if another request fails for certain reason.  
+
+A typical example is the silent login operation; if you receive an `unathorized` or `.forbidden` error for a protected resource you may want to try a silent login operation, then re-execute initial failed request.
+
+The `HTTPAltRequestValidator` is triggered by certain HTTP status code; by default `401/403` and require a callback which return a specific `HTTPRequestProtocol` for a certain failed request. 
+
+> **NOTE:** By default this validator is not triggered by network failure. If you want to perform it even when no response is received from server add the `HTTPStatusCode` `.none` to the list of `triggeredHTTPCodes` property.
+
+Usually you may want to be the first validator (before the default one).  
+This is an example which perform a 
+
+```swift
+let client = HTTPClient(...)
+// The alt validator is triggered only when 401 error is received from any request's response.
+let authValidator = HTTPAltRequestValidator(statusCodes: [.unauthorized], { request, response in
+    // If triggered here you'll specify the alt call to execute in order to refresh a JWT session token
+    // before any retry of the initial failed request.
+    return HTTPRequest("https://.../refreshToken")
+} onReceiveAltResponse: { request, response in
+    // Once you have received response from your `refreshToken` call
+    // you can do anything you need to use it.
+    // In this example we'll set the global client's authorization header.
+    let receivedToken = response.data...
+    client.headers.set(.authorization, receivedToken)
+}
+
+// append at the top of the validators chain
+client.validators.insert(authValidator, at: 0)
+```
 
 ## Custom Validators
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ RealHTTP is provided with an extensive documentation.
     - [Fail with error](./Documentation/3.Advanced_HTTPClient.md#fail-with-error)
     - [Retry with strategy](./Documentation/3.Advanced_HTTPClient.md#retry-with-strategy)
   - [The Default Validator](./Documentation/3.Advanced_HTTPClient.md#the-default-validator)
+  - [Alt Request Validator](./Documentation/3.Advanced_HTTPClient.md#alt-request-validator)
   - [Custom Validators](./Documentation/3.Advanced_HTTPClient.md#custom-validators)
   - [Retry After [Another] Call](./Documentation/3.Advanced_HTTPClient.md#retry-after-another-call)
 - [**4 - Handle Large Data Request**](./Documentation/4.Handle_LargeData_Requests.md#handle-large-data-request)

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
@@ -18,35 +18,46 @@ import Foundation
 /// This validator can be used to provide an alternate request operation to execute before
 /// retry the initial request. It may be used to provide silent login operation when you receive
 /// and authorized/forbidden errors.
+///
 /// It's triggered by the `triggerHTTPCodes` which by default is set `.unathorized, .forbidden`.
 open class HTTPAltRequestValidator: HTTPValidator {
     public typealias RetryRequestProvider = ((_ request: HTTPRequest, _ response: HTTPResponse) -> HTTPRequest?)
     
-    // MARK: - Public Properties
+    // MARK: - Public Properties (Configuration Options)
     
-    /// Trigger codes.
-    open var triggerHTTPCodes: Set<HTTPStatusCode>
+    /// HTTP status codes which trigger the validator callback.
+    ///
+    /// NOTE:
+    /// If you want to trigger the no-response (ie. network failure) you should
+    /// add `none` in triggered status code response.
+    open var statusCodes: Set<HTTPStatusCode>
     
-    /// Provider of the request.
-    open var requestProvider: RetryRequestProvider
+    /// This is the delay to retry the initial request after the alt request
+    /// has been executed. By default is 0s.
+    open var retryDelay: TimeInterval = 0
     
-    /// This allows you to observe the response of the alt request executed
-    /// and perform your own logic before retry the initial call failed.
+    /// Number of alternate calls to execute.
+    /// By default is set to 1.
+    /// It means the first alternate call which fails on a certain
+    /// request will fails any other request in the same session.
+    open var maxAltRequests = 1
+    
+    // MARK: - Public Properties (Observable Events)
+    
+    /// This callback is called when validator ask to you to provide the
+    /// alternate request to execute before retry the initial failed call.
+    open var onProvideAltRequest: RetryRequestProvider
+    
+    /// This callback is called when the alternate request did finish and
+    /// you want to read and so something with the response.
+    /// This is an async call you can use to perform your own logic before
+    /// the initial call is retried automatically.
     ///
     /// For example if your strategy is to try a silent login in your
     /// alt request you can use this method setup received response with
     /// the token as your session cookies so when the initial call is retried
     /// everything will be okay.
-    open var altRequestCatcher: HTTPRetryStrategy.AltRequestCatcher?
-    
-    /// This is the delay to retry the initial request after the alt request
-    /// has been executed. By default is 0s.
-    open var retryMainCallDelay: TimeInterval = 0
-    
-    /// Number of alternate calls to execute.
-    /// By default is set to 1. It means the first alternate call which fails on a certain
-    /// request will fails any other request in the same session.
-    open var maxAltRequestsToExecute: Int? = nil
+    open var onReceiveAltResponse: HTTPRetryStrategy.AltRequestCatcher?
     
     // MARK: - Private Properties
     
@@ -55,17 +66,22 @@ open class HTTPAltRequestValidator: HTTPValidator {
     
     // MARK: - Initialization
     
-    /// Initialize to provide a new request when a code is triggered.
-    /// The alternate request is executed in case of triggered errors, then the original request is re-executed.
+    /// Initialize to provide a new request when one of `triggeredCodes` arrives.
     ///
     /// - Parameters:
-    ///   - triggerCodes: trigger http codes, by default `[.unauthorized, .forbidden]`.
-    ///   - requestProvider: provider of the alternate request to execute.
-    public init(triggerCodes: Set<HTTPStatusCode> = [.unauthorized, .forbidden],
-                _ requestProvider: @escaping RetryRequestProvider) {
-        self.triggerHTTPCodes = triggerCodes
-        self.requestProvider = requestProvider
+    ///   - statusCodes: array of `HTTPStatusCode` which trigger the validator (default is `[.unauthorized, .forbidden]`)
+    ///   - onProvideAltRequest: the function which ask what alternate request you want
+    ///                          to execute when a initial request is received
+    ///   - onReceiveAltResponse: use this callback to catch the response received by the alt request and perform your logic.
+    public init(statusCodes: Set<HTTPStatusCode> = [.unauthorized, .forbidden],
+                onProvideAltRequest: @escaping RetryRequestProvider,
+                onReceiveAltResponse: HTTPRetryStrategy.AltRequestCatcher?) {
+        self.statusCodes = statusCodes
+        self.onProvideAltRequest = onProvideAltRequest
+        self.onReceiveAltResponse = onReceiveAltResponse
     }
+    
+    // MARK: - Public Functions
     
     /// Reset the state of alt requests executed.
     public func reset() {
@@ -75,25 +91,25 @@ open class HTTPAltRequestValidator: HTTPValidator {
     // MARK: - Protocol Conformance
     
     public func validate(response: HTTPResponse, forRequest request: HTTPRequest) -> HTTPResponseValidatorResult {
-        if let statusCode = response.error?.statusCode, triggerHTTPCodes.contains(statusCode) {
+        guard triggerHTTPCodes.contains(response.statusCode) else {
+            // if received status code for this request is not inside the triggerable status codes we'll skip the validator.
+            return .nextValidator
+        }
+                
+        numberOfAltRequestExecuted += 1
+        
+        if numberOfAltRequestExecuted > maxAltRequests {
+            // If we reached the maximum number of alternate calls to execute we want to cancel any other attempt.
+            return .failChain(HTTPError(.maxRetryAttemptsReached))
+        }
+
+        // if no retry operation is provided we'll skip and mark the validation as passed
+        guard let altOperation = onProvideAltRequest(request, response) else {
             return .nextValidator
         }
         
-        // If error is one of the errors in `triggerHTTPCodes`
-        
-        // If we reached the maximum number of alternate calls to execute we want to cancel any other attempt.
-        numberOfAltRequestExecuted += 1
-        if let maxAltRequestsToExecute = maxAltRequestsToExecute,
-              numberOfAltRequestExecuted > maxAltRequestsToExecute {
-            let error = HTTPError(.maxRetryAttemptsReached)
-            return .failChain(error)
-        }
-        
-        guard let altOperation = requestProvider(request, response) else {
-            return .nextValidator // if no retry operation is provided we'll skip and mark the validation as passed
-        }
-        
-        return .retry(.after(altOperation, retryMainCallDelay, altRequestCatcher))
+        // Perform the alt request strategy.
+        return .retry(.after(altOperation, retryDelay, onReceiveAltResponse))
     }
     
 }

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
@@ -1,0 +1,99 @@
+//
+//  RealHTTP
+//  Lightweight Async/Await Network Layer/Stubber for Swift
+//
+//  Created & Maintained by Mobile Platforms Team @ ImmobiliareLabs.it
+//  Email: mobile@immobiliare.it
+//  Web: http://labs.immobiliare.it
+//
+//  Authors:
+//   - Daniele Margutti <hello@danielemargutti.com>
+//
+//  Copyright ©2022 Immobiliare.it SpA.
+//  Licensed under MIT License.
+//
+
+import Foundation
+
+/// This validator can be used to provide an alternate request operation to execute before
+/// retry the initial request. It may be used to provide silent login operation when you receive
+/// and authorized/forbidden errors.
+/// It's triggered by the `triggerHTTPCodes` which by default is set `.unathorized, .forbidden`.
+open class HTTPAltRequestValidator: HTTPValidator {
+    public typealias RetryRequestProvider = ((_ request: HTTPRequest, _ response: HTTPResponse) -> HTTPRequest?)
+    
+    // MARK: - Public Properties
+    
+    /// Trigger codes.
+    open var triggerHTTPCodes: Set<HTTPStatusCode>
+    
+    /// Provider of the request.
+    open var requestProvider: RetryRequestProvider
+    
+    /// This allows you to observe the response of the alt request executed
+    /// and perform your own logic before retry the initial call failed.
+    ///
+    /// For example if your strategy is to try a silent login in your
+    /// alt request you can use this method setup received response with
+    /// the token as your session cookies so when the initial call is retried
+    /// everything will be okay.
+    open var altRequestCatcher: HTTPRetryStrategy.AltRequestCatcher?
+    
+    /// This is the delay to retry the initial request after the alt request
+    /// has been executed. By default is 0s.
+    open var retryMainCallDelay: TimeInterval = 0
+    
+    /// Number of alternate calls to execute.
+    /// By default is set to 1. It means the first alternate call which fails on a certain
+    /// request will fails any other request in the same session.
+    open var maxAltRequestsToExecute: Int? = nil
+    
+    // MARK: - Private Properties
+    
+    /// Number of executed alternate request.
+    private var numberOfAltRequestExecuted = 0
+    
+    // MARK: - Initialization
+    
+    /// Initialize to provide a new request when a code is triggered.
+    /// The alternate request is executed in case of triggered errors, then the original request is re-executed.
+    ///
+    /// - Parameters:
+    ///   - triggerCodes: trigger http codes, by default `[.unauthorized, .forbidden]`.
+    ///   - requestProvider: provider of the alternate request to execute.
+    public init(triggerCodes: Set<HTTPStatusCode> = [.unauthorized, .forbidden],
+                _ requestProvider: @escaping RetryRequestProvider) {
+        self.triggerHTTPCodes = triggerCodes
+        self.requestProvider = requestProvider
+    }
+    
+    /// Reset the state of alt requests executed.
+    public func reset() {
+        numberOfAltRequestExecuted = 0
+    }
+    
+    // MARK: - Protocol Conformance
+    
+    public func validate(response: HTTPResponse, forRequest request: HTTPRequest) -> HTTPResponseValidatorResult {
+        if let statusCode = response.error?.statusCode, triggerHTTPCodes.contains(statusCode) {
+            return .nextValidator
+        }
+        
+        // If error is one of the errors in `triggerHTTPCodes`
+        
+        // If we reached the maximum number of alternate calls to execute we want to cancel any other attempt.
+        numberOfAltRequestExecuted += 1
+        if let maxAltRequestsToExecute = maxAltRequestsToExecute,
+              numberOfAltRequestExecuted > maxAltRequestsToExecute {
+            let error = HTTPError(.maxRetryAttemptsReached)
+            return .failChain(error)
+        }
+        
+        guard let altOperation = requestProvider(request, response) else {
+            return .nextValidator // if no retry operation is provided we'll skip and mark the validation as passed
+        }
+        
+        return .retry(.after(altOperation, retryMainCallDelay, altRequestCatcher))
+    }
+    
+}


### PR DESCRIPTION
This validator can be used to provide an alternate request operation to execute before retry the initial request. It may be used to provide silent login operation when you receive and authorized/forbidden errors.
It's triggered by the `triggerHTTPCodes` which by default is set `.unathorized, .forbidden`.

The old implementation [is here](https://github.com/immobiliare/RealHTTP/blob/0.9.17/Sources/RealHTTP/Response/Validators/HTTPAltRequestValidator.swift) and should be pretty straightforward to integrate into the new API design.