### PR TITLE
#27 - Fixes for retry mechanism of the HTTPAltRequestValidator

### DIFF
--- a/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
+++ b/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
@@ -106,7 +106,11 @@ public struct HTTPResponse: CustomStringConvertible {
     ///   - errorType: error type.
     ///   - error: optional error instance received.
     internal init(errorType: HTTPError.ErrorCategory = .internal, error: Error?) {
-        self.error = HTTPError(errorType, error: error)
+        if let httpError = error as? HTTPError {
+            self.error = httpError
+        } else {
+            self.error = HTTPError(errorType, error: error)
+        }
         self.innerData = nil
         self.metrics = nil
         self.urlResponse = nil

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
@@ -37,10 +37,10 @@ open class HTTPAltRequestValidator: HTTPValidator {
     open var retryDelay: TimeInterval = 0
     
     /// Number of alternate calls to execute.
-    /// By default is set to 1.
+    /// By default is set to `nil`.
     /// It means the first alternate call which fails on a certain
     /// request will fails any other request in the same session.
-    open var maxAltRequests = 1
+    open var maxAltRequests: Int? = nil
     
     // MARK: - Public Properties (Observable Events)
     
@@ -85,7 +85,7 @@ open class HTTPAltRequestValidator: HTTPValidator {
     
     /// Reset the state of alt requests executed.
     public func reset() {
-        numberOfAltRequestExecuted = 0
+        //numberOfAltRequestExecuted = 0
     }
     
     // MARK: - Protocol Conformance
@@ -96,7 +96,7 @@ open class HTTPAltRequestValidator: HTTPValidator {
             return .nextValidator
         }
                         
-        if numberOfAltRequestExecuted > maxAltRequests {
+        if let maxAltRequests = maxAltRequests, numberOfAltRequestExecuted >= maxAltRequests {
             // If we reached the maximum number of alternate calls to execute we want to cancel any other attempt.
             return .failChain(HTTPError(.maxRetryAttemptsReached))
         }

--- a/Sources/RealHTTP/Client/Internal/Other Structures/HTTPError.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/HTTPError.swift
@@ -17,7 +17,7 @@ import Foundation
 
 /// `HTTPError` represent an object which wrap all the infos related to an
 /// error occurred inside the library itself.
-public struct HTTPError: LocalizedError {
+public struct HTTPError: LocalizedError, CustomStringConvertible {
     
     /// HTTP Status Code if available.
     public let statusCode: HTTPStatusCode
@@ -74,6 +74,17 @@ public struct HTTPError: LocalizedError {
     /// Return `true` if error is about a missing authorization.
     public var isNotAuthorized: Bool {
         statusCode == .unauthorized
+    }
+    
+    public var description: String {
+        return """
+            Error {
+                HTTP Code:  \(statusCode)
+                Category:   \(category)
+                Cocoa Code: \(cocoaCode ?? 0)
+                Message:    \(error?.localizedDescription ?? "-")
+            }
+        """
     }
     
 }


### PR DESCRIPTION
The following PR fixes an issue with the retry mechanism of the `HTTPAltRequestValidator` and introduces several unit tests for this class.