### PR TITLE
#26 - Added shortcuts to cast body to common structures

### DIFF
--- a/Sources/RealHTTP/Client/Internal/HTTPBody/HTTPBody.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/HTTPBody.swift
@@ -74,3 +74,18 @@ extension HTTPBody {
     }
     
 }
+
+
+extension HTTPBody {
+    
+    /// Return content as Data.
+    public var asData: Data? {
+        content as? Data
+    }
+    
+    /// Return content as String.
+    public var asString: String? {
+        content as? String
+    }
+    
+}

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/JSON/JSONEncodable.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/JSON/JSONEncodable.swift
@@ -56,6 +56,15 @@ extension HTTPBody {
     
 }
 
+extension HTTPBody {
+    
+    /// Return content as `JSONEncodable`.
+    public var asJSONEncodable: JSONEncodable? {
+        content as? JSONEncodable
+    }
+    
+}
+
 // MARK: - AnyEncodable
 
 /// This is used only to encapsulate an Encodable object with type-erasure.

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/JSON/JSONSerializable.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/JSON/JSONSerializable.swift
@@ -47,3 +47,12 @@ extension HTTPBody {
     }
     
 }
+
+extension HTTPBody {
+    
+    /// Return content as `JSONSerialization` object.
+    public var asJSONSerializable: JSONSerializable? {
+        content as? JSONSerializable
+    }
+    
+}

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/Multipart/HTTPBody+Multipart.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/Multipart/HTTPBody+Multipart.swift
@@ -38,3 +38,12 @@ extension HTTPBody {
     }
     
 }
+
+extension HTTPBody {
+    
+    /// Return content as `MultipartForm`.
+    public var asMultipartForm: MultipartForm? {
+        content as? MultipartForm
+    }
+    
+}

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/Stream/HTTPBody+Stream.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/Stream/HTTPBody+Stream.swift
@@ -32,3 +32,12 @@ extension HTTPBody {
     }
     
 }
+
+extension HTTPBody {
+ 
+    /// Return the body as `StreamContent`.
+    public var asStream: StreamContent? {
+        content as? StreamContent
+    }
+    
+}

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/URLParametersData/HTTPBody+QueryString.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/URLParametersData/HTTPBody+QueryString.swift
@@ -61,7 +61,7 @@ extension HTTPBody {
         // MARK: - Public Properties
         
         /// Parameters to set with url encoded body.
-        public let parameters: URLParametersData
+        public let data: URLParametersData
         
         // MARK: - Initialziation
         
@@ -69,13 +69,45 @@ extension HTTPBody {
         ///
         /// - Parameter parameters: parameters.
         public init(_ parameters: HTTPRequestParametersDict) {
-            self.parameters = URLParametersData(parameters)
+            self.data = URLParametersData(parameters)
+        }
+        
+        /// Add parameter to the form url encoded.
+        /// If the value is `nil` no action is taken.
+        ///
+        /// - Parameters:
+        ///   - value: value to add.
+        ///   - key: key to use.
+        public func set(value: Any?, forKey key: String) {
+            guard let value = value else {
+                return
+            }
+
+            data.parameters?[key] = value
+        }
+        
+        /// Remove value for a given key and return the removed value, if any.
+        ///
+        /// - Parameter key: key.
+        /// - Returns: `T?`
+        @discardableResult
+        public func removeValueForKey<T>(_ key: String) -> T? {
+            data.parameters?.removeValue(forKey: key) as? T
+        }
+        
+        /// Remove value for a given key and return the removed value, if any.
+        ///
+        /// - Parameter key: key.
+        /// - Returns: `Any`
+        @discardableResult
+        public func removeValueForKey(_ key: String) -> Any? {
+            data.parameters?.removeValue(forKey: key)
         }
         
         // MARK: - HTTPSerializableBody Conformance
         
         public func serializeData() async throws -> (data: Data, additionalHeaders: HTTPHeaders?) {
-            try await parameters.serializeData()
+            try await data.serializeData()
         }
         
     }

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/URLParametersData/HTTPBody+QueryString.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/URLParametersData/HTTPBody+QueryString.swift
@@ -42,6 +42,15 @@ extension HTTPBody {
     
 }
 
+extension HTTPBody {
+    
+    /// Return body as `WWWFormURLEncodedBody`.
+    public var asFormURLEncoded: WWWFormURLEncodedBody? {
+        content as? WWWFormURLEncodedBody
+    }
+    
+}
+
 // MARK: - WWWFormURLEncoded
 
 extension HTTPBody {

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/URLParametersData/URLParametersData.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/URLParametersData/URLParametersData.swift
@@ -43,7 +43,7 @@ extension HTTPBody {
         ///                   The default behaviour is `asNumbers` where `true=1`, `false=0`.
         ///   - arrayEncoding: Specify how array parameter's value are encoded into the request.
         ///                    By default the `withBrackets` option is used and array are encoded as `key[]=value`.
-        internal init(_ parameters: HTTPRequestParametersDict?,
+        public init(_ parameters: HTTPRequestParametersDict?,
                       boolEncoding: BoolEncodingStyle = .asNumbers,
                       arrayEncoding: ArrayEncodingStyle = .withBrackets) {
             self.parameters = parameters


### PR DESCRIPTION
The following merge request introducethe following shortcuts to `body` (`HTTPBody`) so you can modify it anytime before executing the request:

- `asData` and `asString` to cast `body` to `Data` and `String`
- `asFormURLEncoded` to cast `body` to `WWWFormURLEncodedBody`
- `asMultipartForm` to cast `body` to `MultipartForm`
- `asStream` to cast `body` to `asStream`

it also introduces `public init` for the common body types.

### Example

Consider the following init:

```swift
let req = HTTPRequest {
   $0.body = .formURLEncodedBody(["username": "Michael Bublé", "pwd": "abc"])
}
```

You can add or remove values:

```swift
req.body.asFormURLEncoded?.set(value: "newValue", forKey: "newKey")
req.body.asFormURLEncoded?.removeValueForKey("newKey")
```