### PR TITLE
#34 Fix for custom error dispatch for decode() and throws

### DIFF
--- a/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
+++ b/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
@@ -66,7 +66,7 @@ public struct HTTPResponse: CustomStringConvertible {
     public private(set) var dataFileURL: URL?
     
     /// Error parsed.
-    public let error: HTTPError?
+    public internal(set) var error: HTTPError?
     
     /// Return `true` if call ended with error.
     public var isError: Bool {
@@ -106,16 +106,12 @@ public struct HTTPResponse: CustomStringConvertible {
     ///   - errorType: error type.
     ///   - error: optional error instance received.
     internal init(errorType: HTTPError.ErrorCategory = .internal, error: Error?) {
-        if let httpError = error as? HTTPError {
-            self.error = httpError
-        } else {
-            self.error = HTTPError(errorType, error: error)
-        }
         self.innerData = nil
         self.metrics = nil
         self.urlResponse = nil
         self.dataFileURL = nil
         self.statusCode = .none
+        setError(category: errorType, error)
     }
     
     /// Initialize with response from data loader.
@@ -131,7 +127,6 @@ public struct HTTPResponse: CustomStringConvertible {
         self.request = response.request
         self.urlRequests = response.urlRequests
     }
-    
     
     // MARK: - Decoding
     
@@ -163,6 +158,21 @@ public struct HTTPResponse: CustomStringConvertible {
 
         let object = try JSONSerialization.jsonObject(with: data, options: options)
         return object as? T
+    }
+    
+    // MARK: - Internal Functions
+        
+    /// Attach an error to the response by modifing the original error instance, if any.
+    ///
+    /// - Parameters:
+    ///   - category: error category.
+    ///   - error: error instance.
+    internal mutating func setError(category: HTTPError.ErrorCategory, _ error: Error?) {
+        if let httpError = error as? HTTPError {
+            self.error = httpError
+        } else {
+            self.error = HTTPError(category, error: error)
+        }
     }
         
 }

--- a/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
+++ b/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
@@ -134,6 +134,10 @@ public struct HTTPResponse: CustomStringConvertible {
     ///
     /// - Returns: `T` or `nil` if no response has been received.
     public func decode<T: Decodable>(_ decodable: T.Type, decoder: JSONDecoder = .init()) throws -> T {
+        if let error = error {
+            throw error // dispatch any error coming from fetch outside the decode.
+        }
+        
         guard let data = data else {
             throw HTTPError.init(.emptyResponse)
         }
@@ -154,6 +158,11 @@ public struct HTTPResponse: CustomStringConvertible {
     /// - Returns: T?
     public func decodeJSONData<T>(_ decodable: T.Type,
                                   options: JSONSerialization.ReadingOptions = []) throws -> T? {
+        
+        if let error = error {
+            throw error // dispatch any error coming from fetch outside the decode.
+        }
+        
         guard let data = data else { return nil }
 
         let object = try JSONSerialization.jsonObject(with: data, options: options)

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
@@ -98,7 +98,7 @@ open class HTTPAltRequestValidator: HTTPValidator {
                         
         if let maxAltRequests = maxAltRequests, numberOfAltRequestExecuted >= maxAltRequests {
             // If we reached the maximum number of alternate calls to execute we want to cancel any other attempt.
-            return .failChain(HTTPError(.maxRetryAttemptsReached))
+            return .failChain(HTTPError(.retryAttemptsReached))
         }
 
         // if no retry operation is provided we'll skip and mark the validation as passed

--- a/Sources/RealHTTP/Client/Internal/Other Structures/HTTPError.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/HTTPError.swift
@@ -25,11 +25,11 @@ public struct HTTPError: LocalizedError, CustomStringConvertible {
     /// Cocoa related code.
     public var cocoaCode: Int?
     
-    /// Long description of the error.
+    /// Underlying error.
     public let error: Error?
     
     /// Category of the error.
-    public let category: ErrorCategory
+    public internal(set) var category: ErrorCategory
     
     /// Additional user info.
     public var userInfo: [String: Any]?
@@ -77,14 +77,7 @@ public struct HTTPError: LocalizedError, CustomStringConvertible {
     }
     
     public var description: String {
-        return """
-            Error {
-                HTTP Code:  \(statusCode)
-                Category:   \(category)
-                Cocoa Code: \(cocoaCode ?? 0)
-                Message:    \(error?.localizedDescription ?? "-")
-            }
-        """
+        "HTTPError {httpCode=\(statusCode), category=\(category), cocoa=\(cocoaCode ?? 0), description='\(errorDescription ?? "")'}"
     }
     
 }
@@ -106,10 +99,10 @@ public extension HTTPError {
     /// - `objectDecodeFailed`: object decoding failed
     /// - `emptyResponse`: empty response received from server
     /// - `maxRetryAttemptsReached`: the maximum number of retries for request has been reached
-    /// - `maxRetryAltRequestReached`: the maximum number of alternate request for this session has been reached
     /// - `sessionError`: error related to the used session instances (may be a systemic error or it was invalidated)
     /// - `other`: any internal error, you can use it as your own handler.
     /// - `cancelled`: cancelled by user.
+    /// - `validatorFailure`: failure returned by a validator set.
     /// - `internal`: internal library error occurred.
     enum ErrorCategory: Int {
         case invalidURL
@@ -124,12 +117,12 @@ public extension HTTPError {
         case failedBuildingURLRequest
         case objectDecodeFailed
         case emptyResponse
-        case maxRetryAttemptsReached
-        case maxRetryAltRequestReached
+        case retryAttemptsReached
         case sessionError
         case other
         case cancelled
         case timeout
+        case validatorFailure
         case `internal`
     }
     

--- a/Tests/RealHTTPTests/Requests+Tests.swift
+++ b/Tests/RealHTTPTests/Requests+Tests.swift
@@ -709,7 +709,6 @@ class RequestsTests: XCTestCase {
         defer { stopStubber() }
         
         let regex = String(request.path.dropFirst())
-        print(regex)
         let stub = HTTPStubRequest().match(urlRegex: regex).stub(for: .get, responseProvider: callback)
         HTTPStubber.shared.add(stub: stub)
         


### PR DESCRIPTION
This PR fixes #34 where you can throw a custom error in validator phase and get it as output both from `fetch()` and `decode()` function.