### PR TITLE
#38 HTTPStubRegExMatcher and match(urlRegEx) for stubber now throws

### DIFF
--- a/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
+++ b/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
@@ -66,7 +66,7 @@ public struct HTTPResponse: CustomStringConvertible {
     public private(set) var dataFileURL: URL?
     
     /// Error parsed.
-    public let error: HTTPError?
+    public internal(set) var error: HTTPError?
     
     /// Return `true` if call ended with error.
     public var isError: Bool {
@@ -106,16 +106,12 @@ public struct HTTPResponse: CustomStringConvertible {
     ///   - errorType: error type.
     ///   - error: optional error instance received.
     internal init(errorType: HTTPError.ErrorCategory = .internal, error: Error?) {
-        if let httpError = error as? HTTPError {
-            self.error = httpError
-        } else {
-            self.error = HTTPError(errorType, error: error)
-        }
         self.innerData = nil
         self.metrics = nil
         self.urlResponse = nil
         self.dataFileURL = nil
         self.statusCode = .none
+        setError(category: errorType, error)
     }
     
     /// Initialize with response from data loader.
@@ -131,7 +127,6 @@ public struct HTTPResponse: CustomStringConvertible {
         self.request = response.request
         self.urlRequests = response.urlRequests
     }
-    
     
     // MARK: - Decoding
     
@@ -163,6 +158,21 @@ public struct HTTPResponse: CustomStringConvertible {
 
         let object = try JSONSerialization.jsonObject(with: data, options: options)
         return object as? T
+    }
+    
+    // MARK: - Internal Functions
+        
+    /// Attach an error to the response by modifing the original error instance, if any.
+    ///
+    /// - Parameters:
+    ///   - category: error category.
+    ///   - error: error instance.
+    internal mutating func setError(category: HTTPError.ErrorCategory, _ error: Error?) {
+        if let httpError = error as? HTTPError {
+            self.error = httpError
+        } else {
+            self.error = HTTPError(category, error: error)
+        }
     }
         
 }

--- a/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
+++ b/Sources/RealHTTP/Client/HTTPResponse/HTTPResponse.swift
@@ -134,6 +134,10 @@ public struct HTTPResponse: CustomStringConvertible {
     ///
     /// - Returns: `T` or `nil` if no response has been received.
     public func decode<T: Decodable>(_ decodable: T.Type, decoder: JSONDecoder = .init()) throws -> T {
+        if let error = error {
+            throw error // dispatch any error coming from fetch outside the decode.
+        }
+        
         guard let data = data else {
             throw HTTPError.init(.emptyResponse)
         }
@@ -154,6 +158,11 @@ public struct HTTPResponse: CustomStringConvertible {
     /// - Returns: T?
     public func decodeJSONData<T>(_ decodable: T.Type,
                                   options: JSONSerialization.ReadingOptions = []) throws -> T? {
+        
+        if let error = error {
+            throw error // dispatch any error coming from fetch outside the decode.
+        }
+        
         guard let data = data else { return nil }
 
         let object = try JSONSerialization.jsonObject(with: data, options: options)

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
@@ -98,7 +98,7 @@ open class HTTPAltRequestValidator: HTTPValidator {
                         
         if let maxAltRequests = maxAltRequests, numberOfAltRequestExecuted >= maxAltRequests {
             // If we reached the maximum number of alternate calls to execute we want to cancel any other attempt.
-            return .failChain(HTTPError(.maxRetryAttemptsReached))
+            return .failChain(HTTPError(.retryAttemptsReached))
         }
 
         // if no retry operation is provided we'll skip and mark the validation as passed

--- a/Sources/RealHTTP/Client/Internal/Other Structures/HTTPError.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/HTTPError.swift
@@ -25,11 +25,11 @@ public struct HTTPError: LocalizedError, CustomStringConvertible {
     /// Cocoa related code.
     public var cocoaCode: Int?
     
-    /// Long description of the error.
+    /// Underlying error.
     public let error: Error?
     
     /// Category of the error.
-    public let category: ErrorCategory
+    public internal(set) var category: ErrorCategory
     
     /// Additional user info.
     public var userInfo: [String: Any]?
@@ -77,14 +77,7 @@ public struct HTTPError: LocalizedError, CustomStringConvertible {
     }
     
     public var description: String {
-        return """
-            Error {
-                HTTP Code:  \(statusCode)
-                Category:   \(category)
-                Cocoa Code: \(cocoaCode ?? 0)
-                Message:    \(error?.localizedDescription ?? "-")
-            }
-        """
+        "HTTPError {httpCode=\(statusCode), category=\(category), cocoa=\(cocoaCode ?? 0), description='\(errorDescription ?? "")'}"
     }
     
 }
@@ -106,10 +99,10 @@ public extension HTTPError {
     /// - `objectDecodeFailed`: object decoding failed
     /// - `emptyResponse`: empty response received from server
     /// - `maxRetryAttemptsReached`: the maximum number of retries for request has been reached
-    /// - `maxRetryAltRequestReached`: the maximum number of alternate request for this session has been reached
     /// - `sessionError`: error related to the used session instances (may be a systemic error or it was invalidated)
     /// - `other`: any internal error, you can use it as your own handler.
     /// - `cancelled`: cancelled by user.
+    /// - `validatorFailure`: failure returned by a validator set.
     /// - `internal`: internal library error occurred.
     enum ErrorCategory: Int {
         case invalidURL
@@ -124,12 +117,12 @@ public extension HTTPError {
         case failedBuildingURLRequest
         case objectDecodeFailed
         case emptyResponse
-        case maxRetryAttemptsReached
-        case maxRetryAltRequestReached
+        case retryAttemptsReached
         case sessionError
         case other
         case cancelled
         case timeout
+        case validatorFailure
         case `internal`
     }
     

--- a/Sources/RealHTTP/Stubber/DataTypes/HTTPStubIgnoreRule.swift
+++ b/Sources/RealHTTP/Stubber/DataTypes/HTTPStubIgnoreRule.swift
@@ -67,11 +67,8 @@ public class HTTPStubIgnoreRule: Equatable {
     ///   - pattern: pattern for validation.
     ///   - options: options for regular expression.
     /// - Returns: Self
-    public func match(urlRegex pattern: String, options: NSRegularExpression.Options = []) -> Self {
-        guard let matcher = HTTPStubRegExMatcher(regex: pattern, options: options, in: .url) else {
-            return self
-        }
-        
+    public func match(urlRegex pattern: String, options: NSRegularExpression.Options = []) throws -> Self {
+        let matcher = try HTTPStubRegExMatcher(regex: pattern, options: options, in: .url)
         return match(matcher)
     }
     

--- a/Sources/RealHTTP/Stubber/DataTypes/Stub Matchers/Built-In Matchers/HTTPStubRegExMatcher.swift
+++ b/Sources/RealHTTP/Stubber/DataTypes/Stub Matchers/Built-In Matchers/HTTPStubRegExMatcher.swift
@@ -37,13 +37,9 @@ public class HTTPStubRegExMatcher: HTTPStubMatcher {
     ///   - pattern: regex pattern to validate.
     ///   - options: options for regular expression matching.
     ///   - location: where to validate the regular expression.
-    public init?(regex pattern: String, options: NSRegularExpression.Options = [], in location: HTTPMatcherLocation) {
-        do {
-            self.regex = try NSRegularExpression(pattern: pattern, options: options)
-            self.location = location
-        } catch {
-            return nil
-        }
+    public init(regex pattern: String, options: NSRegularExpression.Options = [], in location: HTTPMatcherLocation) throws {
+        self.regex = try NSRegularExpression(pattern: pattern, options: options)
+        self.location = location
     }
     
     // MARK: - Conformances

--- a/Sources/RealHTTP/Stubber/DataTypes/Stub Request/HTTPStubRequest+Matchers.swift
+++ b/Sources/RealHTTP/Stubber/DataTypes/Stub Request/HTTPStubRequest+Matchers.swift
@@ -41,11 +41,8 @@ extension HTTPStubRequest {
     ///   - pattern: pattern for validation.
     ///   - options: options for regular expression.
     /// - Returns: Self
-    public func match(urlRegex pattern: String, options: NSRegularExpression.Options = []) -> Self {
-        guard let matcher = HTTPStubRegExMatcher(regex: pattern, options: options, in: .url) else {
-            return self
-        }
-        
+    public func match(urlRegex pattern: String, options: NSRegularExpression.Options = []) throws -> Self {
+        let matcher = try HTTPStubRegExMatcher(regex: pattern, options: options, in: .url)
         return match(matcher)
     }
     

--- a/Sources/RealHTTP/Stubber/HTTPStubber.swift
+++ b/Sources/RealHTTP/Stubber/HTTPStubber.swift
@@ -138,11 +138,8 @@ public class HTTPStubber {
     ///   - options: regular expression matching options.
     /// - Returns: Self
     @discardableResult
-    public func add(ignoreURLRegex regex: String, options: NSRegularExpression.Options = []) -> Self {
-        guard let matcher = HTTPStubRegExMatcher(regex: regex, options: options, in: .url) else {
-            return self
-        }
-        
+    public func add(ignoreURLRegex regex: String, options: NSRegularExpression.Options = []) throws -> Self {
+        let matcher = try HTTPStubRegExMatcher(regex: regex, options: options, in: .url)
         return add(ignore: HTTPStubIgnoreRule(matcher))
     }
     

--- a/Tests/RealHTTPTests/Headers+Tests.swift
+++ b/Tests/RealHTTPTests/Headers+Tests.swift
@@ -38,7 +38,7 @@ class HeadersTests: XCTestCase {
         
         HTTPStubber.shared.enable()
         
-        let echo = HTTPStubRequest().match(urlRegex: "*").stubEcho()
+        let echo = try! HTTPStubRequest().match(urlRegex: "(?s).*").stubEcho()
         HTTPStubber.shared.add(stub: echo)
     }
     

--- a/Tests/RealHTTPTests/Requests+Tests.swift
+++ b/Tests/RealHTTPTests/Requests+Tests.swift
@@ -27,7 +27,7 @@ class RequestsTests: XCTestCase {
         HTTPStubber.shared.removeAllStubs()
         
         if echo {
-            HTTPStubber.shared.add(stub: HTTPStubRequest().match(urlRegex: "*").stubEcho())
+            HTTPStubber.shared.add(stub: try! HTTPStubRequest().match(urlRegex: "(?s).*").stubEcho())
         }
     }
     
@@ -54,10 +54,10 @@ class RequestsTests: XCTestCase {
     override class func setUp() {
         super.setUp()
         
-        HTTPStubber.shared.enable()
+        //HTTPStubber.shared.enable()
         
-        let echo = HTTPStubRequest().match(urlRegex: "*").stubEcho()
-        HTTPStubber.shared.add(stub: echo)
+       // let echo = HTTPStubRequest().match(urlRegex: "*").stubEcho()
+       // HTTPStubber.shared.add(stub: echo)
     }
     
     override class func tearDown() {
@@ -597,7 +597,7 @@ class RequestsTests: XCTestCase {
         }), at: 0)
         
         // Add stubber
-        let stub = HTTPStubRequest().match(urlRegex: "/initial").stub(for: .get) { urlRequest, _ in
+        let stub = try! HTTPStubRequest().match(urlRegex: "/initial").stub(for: .get) { urlRequest, _ in
             let response = HTTPStubResponse()
             response.body = "ciao"
             return response
@@ -636,7 +636,7 @@ class RequestsTests: XCTestCase {
         }), at: 0)
         
         // Add stubber
-        let stub = HTTPStubRequest().match(urlRegex: "/initial").stub(for: .get) { urlRequest, _ in
+        let stub = try! HTTPStubRequest().match(urlRegex: "/initial").stub(for: .get) { urlRequest, _ in
             let response = HTTPStubResponse()
             response.body = "ciao"
             return response
@@ -709,7 +709,7 @@ class RequestsTests: XCTestCase {
         defer { stopStubber() }
         
         let regex = String(request.path.dropFirst())
-        let stub = HTTPStubRequest().match(urlRegex: regex).stub(for: .get, responseProvider: callback)
+        let stub = try! HTTPStubRequest().match(urlRegex: regex).stub(for: .get, responseProvider: callback)
         HTTPStubber.shared.add(stub: stub)
         
         // Prepare client
@@ -751,7 +751,7 @@ class RequestsTests: XCTestCase {
         
         // Prepare the stub responses
         
-        let stubOriginRequest = HTTPStubRequest().match(urlRegex: "/someAuthCall").stub(for: .get, responseProvider: { request, stubRequest in
+        let stubOriginRequest = try! HTTPStubRequest().match(urlRegex: "/someAuthCall").stub(for: .get, responseProvider: { request, stubRequest in
             let response = HTTPStubResponse()
 
             if succedOnRetry == retryMade {
@@ -768,7 +768,7 @@ class RequestsTests: XCTestCase {
         })
         HTTPStubber.shared.add(stub: stubOriginRequest)
         
-        let stubRefreshToken = HTTPStubRequest().match(urlRegex: "/refreshToken").stub(for: .get, responseProvider: { request, stubRequest in
+        let stubRefreshToken = try! HTTPStubRequest().match(urlRegex: "/refreshToken").stub(for: .get, responseProvider: { request, stubRequest in
             let response = HTTPStubResponse()
             response.statusCode = .ok
             response.body = "NEW_TOKEN"
@@ -887,13 +887,13 @@ class RequestsTests: XCTestCase {
         ]
 
         // Stubber to catch /execute call
-        let stubReq = HTTPStubRequest().match(urlRegex: "/execute").stub(for: .get) { response in
+        let stubReq = try! HTTPStubRequest().match(urlRegex: "/execute").stub(for: .get) { response in
             response.statusCode = .unauthorized
             response.body = mainCallErrorResponse
         }
         HTTPStubber.shared.add(stub: stubReq)
         
-        let altStubReq = HTTPStubRequest().match(urlRegex: "/login").stub(for: .get) { response in
+        let altStubReq = try! HTTPStubRequest().match(urlRegex: "/login").stub(for: .get) { response in
             response.statusCode = .internalServerError
             response.body = loginCallErrorResponse
         }
@@ -995,7 +995,7 @@ class RequestsTests: XCTestCase {
         setupStubber(echo: false)
         defer { stopStubber() }
         
-        let stub = HTTPStubRequest().match(urlRegex: "/login").stub(for: .get, delay: 10, code: .ok)
+        let stub = try! HTTPStubRequest().match(urlRegex: "/login").stub(for: .get, delay: 10, code: .ok)
         HTTPStubber.shared.add(stub: stub)
         
         let req = HTTPRequest {
@@ -1120,12 +1120,12 @@ class RequestsTests: XCTestCase {
         
         let newClient = HTTPClient(baseURL: nil)
 
-        let stubInitial = HTTPStubRequest().match(urlRegex: "/initial").stub(for: .get) { response in
+        let stubInitial = try! HTTPStubRequest().match(urlRegex: "/initial").stub(for: .get) { response in
             response.statusCode = .ok
         }
         HTTPStubber.shared.add(stub: stubInitial)
         
-        let stubModified = HTTPStubRequest().match(urlRegex: "/modified").stub(for: .get) { response in
+        let stubModified = try! HTTPStubRequest().match(urlRegex: "/modified").stub(for: .get) { response in
             response.statusCode = .badRequest
         }
         HTTPStubber.shared.add(stub: stubModified)
@@ -1359,11 +1359,11 @@ class RequestsTests: XCTestCase {
     private func setupStubsForRedirectTest() {
         // Create redirect URL
         let redirectURL = URL(string: "http://127.0.0.1:8081/redirected")!
-        let redirectStub = HTTPStubRequest().match(urlRegex: "/login").stub(method: .get, redirectsTo: redirectURL)
+        let redirectStub = try! HTTPStubRequest().match(urlRegex: "/login").stub(method: .get, redirectsTo: redirectURL)
         HTTPStubber.shared.add(stub: redirectStub)
         
         // Create final URL
-        let stubRedirect = HTTPStubRequest().match(urlRegex: "/redirected").stub(for: .get) { response in
+        let stubRedirect = try! HTTPStubRequest().match(urlRegex: "/redirected").stub(for: .get) { response in
             response.statusCode = .ok
             response.body = "redirected".data(using: .utf8)!
         }

--- a/Tests/RealHTTPTests/Requests+Tests.swift
+++ b/Tests/RealHTTPTests/Requests+Tests.swift
@@ -709,7 +709,6 @@ class RequestsTests: XCTestCase {
         defer { stopStubber() }
         
         let regex = String(request.path.dropFirst())
-        print(regex)
         let stub = HTTPStubRequest().match(urlRegex: regex).stub(for: .get, responseProvider: callback)
         HTTPStubber.shared.add(stub: stub)
         


### PR DESCRIPTION
In this PR we have uncovered a possible source of errors; both the `HTTPStubRegExMatcher`'s `init()` and the associated `match(urlRegEx:)` function does not throw in case of a bad regular expression string.  
Both of these functions now throws in order to explicitly uncover possible errors.