### PR TITLE
Concurrent access to HTTPDataLoader causes crash of the lib

### DIFF
--- a/Sources/RealHTTP/Client/Internal/Other Structures/Foundation+Extensions/Foundation+Extension.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/Foundation+Extensions/Foundation+Extension.swift
@@ -331,3 +331,27 @@ extension URLComponents {
     }
     
 }
+
+// MARK: - RWLock
+
+internal class RWLock {
+    
+    // MARK: - Private Properties
+    
+    private let queue = DispatchQueue(label: "com.realhttp.httpdataloader.lock", attributes: .concurrent)
+    
+    // MARK: - Public Functions
+    
+    func concurrentlyRead<T>(_ block: (() throws -> T)) rethrows -> T {
+        return try queue.sync {
+            try block()
+        }
+    }
+    
+    func exclusivelyWrite(_ block: @escaping (() -> Void)) {
+        queue.async(flags: .barrier) {
+            block()
+        }
+    }
+    
+}


### PR DESCRIPTION
When multiple calls attempt to modify from different threads the inner structure inside the `HTTPDataLoader` where the running tasks are maintained, the result is a crash, usually as EXC_BAD_ACCESS.

This PR fixes the bug by adding exclusive access to write the data at the beginning and when a request completes.