### PR TITLE
Fix for headers priority setting between clients, request and body values

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,11 +1,11 @@
-name: "RealHTTP Push CI"
+name: "RealHTTP CI"
 
-on:
+on: 
   push:
-    branches:
+    branches: 
       - main
   pull_request:
-    branches:
+    branches: 
       - '*'
 
 concurrency:
@@ -13,23 +13,19 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
-  SPM:
-    name: SPM Unit Tests
-    timeout-minutes: 60
+  macos-run-tests:
+    name: Unit Tests (Xcode ${{ matrix.xcode }})
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        swift: ["5.6"]
-    runs-on: ${{ matrix.os }}
+        xcode: ["13.4.1"]
+        include:
+          - xcode: "13.4.1"
+            macos: macOS-12
+    runs-on: ${{ matrix.macos }}
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v3
-      - uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: ${{ matrix.swift }}
-      - name: Get swift version
-        run: swift --version
-      - name: Build
-        run: swift build
-      - name: Run tests
+      - uses: actions/checkout@v2
+      - name: Run Tests
         run: swift test

--- a/Sources/RealHTTP/Client/Internal/HTTPBody/HTTPBody.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPBody/HTTPBody.swift
@@ -32,7 +32,13 @@ public struct HTTPBody {
     
     // MARK: - Internal Properties
     
-    /// Additional headers to set.
+    /// Additional headers set by the particular body configuration.
+    ///
+    /// These values may override both client's headers and specific body's headers.
+    /// Final headers are sum of the following properties in order:  
+    ///     - client's common headers
+    ///     - request's body specific headers
+    ///     - request's user defined headers
     internal var headers: HTTPHeaders
     
     // MARK: - Initialization

--- a/Tests/RealHTTPTests/Requests+Tests.swift
+++ b/Tests/RealHTTPTests/Requests+Tests.swift
@@ -1758,7 +1758,7 @@ class RequestsTests: XCTestCase {
         var requests = [HTTPRequest]()
         let newClient = HTTPClient(baseURL: nil)
 
-        for _ in 0..<100 {
+        for _ in 0..<50 {
             let req = try! HTTPRequest(method: .post, "https://www.apple.com",
                                       body: try .json(["title": "foo", "body": "bar", "userId": 1]))
             


### PR DESCRIPTION
The following PR fixes the issue found in #62 with `headers` of a request.  
Due to a design issue `request.headers` are removed automatically when a custom `request.body` is set. 

This is an example of the issue:

```swift
try await HTTPRequest {
  $0.headers = HTTPHeaders([
    authorization:"Bearer \(token)",
    .contentType:"text/json"
  ])
  $0.body = try .multipart(boundary: nil, { form in
    try form.add(string: name, name: "name")
    try form.add(string: surname, name: "surname")
    try form.add(string: email, name: "email")
  }
})
}.fetch()
```

In this example, we set both the `Authorization` and `Content-Type` headers.  
However, when we set the `.body` of the request to a multi-part form-encoded, the specific body configuration sets its additional headers (i.e., `Content-Length`) by replacing the entire `HTTPHeaders` object with its own instead of merging values.

Our fix decuple the `request.headers` and `request.body.headers` in two different objects.  
When the `URLRequest` is generated from a client, values are merged in the following order:
- client's headers (customized by the user, shared among all requests executed in that client instance)
- request.body's headers (automatically set and optionally customized by the user)
- request.header's (set by the user)

A specific unit test was also added to validate the following scenario.