### PR TITLE
Fix: withTaskCancellationHandler deprecation warning

### DIFF
--- a/Sources/RealHTTP/Client/Internal/HTTPDataLoader/HTTPDataLoader.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPDataLoader/HTTPDataLoader.swift
@@ -73,10 +73,7 @@ internal class HTTPDataLoader: NSObject,
         request.client = nil
         
         let box = Box()
-        return try await withTaskCancellationHandler(handler: {
-            // Support for task cancellation
-            box.task?.cancel()
-        }, operation: {
+        return try await withTaskCancellationHandler(operation: {
             // Conversion of the callback system to the async/await version.
             let response: HTTPResponse = try await withUnsafeThrowingContinuation({ continuation in
                 box.task = self.fetch(request, task: sessionTask, completion: { [weak self] response in
@@ -133,6 +130,10 @@ internal class HTTPDataLoader: NSObject,
                 return modifiedResponse
                 
             }
+        }, onCancel: {
+            // Support for task cancellation
+            box.task?.cancel()
+            
         })
     }
     

--- a/Tests/RealHTTPTests/Requests+Tests.swift
+++ b/Tests/RealHTTPTests/Requests+Tests.swift
@@ -402,16 +402,17 @@ class RequestsTests: XCTestCase {
             } else if progress?.percentage == 1 {
                 resumedDownloadFinished = true
             }
-        }.store(in: &observerBag)
-        
-        // At certain point we want to break the download
-        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.5, execute: {
-            // And produce some resumable data for test
-            req.cancel { partialData in
-                print("Produced partial data: \(partialData?.count ?? 0) bytes")
-                req.partialData = partialData // set the partial data to request to allows resume!
+            // At certain point we want to break the download
+            if let progressPercentage = progress?.percentage,
+               progressPercentage > 0.5,
+               req.partialData == nil
+            {
+                req.cancel { partialData in
+                    print("Produced partial data: \(partialData?.count ?? 0) bytes")
+                    req.partialData = partialData // set the partial data to request to allows resume!
+                }
             }
-        })
+        }.store(in: &observerBag)
         
         // Start the first download
         let _ = try await req.fetch(client)


### PR DESCRIPTION
Xcode 14.1RC shows warnings when `withTaskCancellationHandler(handler:operation:)` is used. This is a fix to call the renamed version without any warnings.

Before committing the changes I ran all the tests, and I found out the test `test_largeFileTestResume()` fails because the request cancellation is executed when both the requests have already finished.
This commit also contains a little refactor to the above-mentioned test to cancel the request in a predictable manner.