### PR TITLE
Add a new retry strategy to allow performing async task before retrying a request

### DIFF
--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPValidator.swift
@@ -58,12 +58,15 @@ public enum HTTPResponseValidatorResult {
 ///              - an optional async callback to execute once you got the response of the alt request before retry the original request.
 public enum HTTPRetryStrategy {
     public typealias AltRequestCatcher = ((_ request: HTTPRequest, _ response: HTTPResponse) async throws -> Void)
+    public typealias RetryTask = ((_ originalRequest: HTTPRequest) async throws -> Void)
+    public typealias RetryTaskErrorCatcher = ((_ error: Error) async -> Void)
     
     case immediate
     case delayed(_ interval: TimeInterval)
     case exponential(_ base: Int)
     case fibonacci
     case after(HTTPRequest, TimeInterval, AltRequestCatcher?)
+    case afterTask(TimeInterval, RetryTask, RetryTaskErrorCatcher?)
     
     // MARK: - Internal Functions
     
@@ -98,6 +101,9 @@ public enum HTTPRetryStrategy {
             return Double(fibonacci(n: numberOfPreviousAttempts))
             
         case .after:
+            return 0
+
+        case .afterTask:
             return 0
         }
     }

--- a/Tests/RealHTTPTests/Requests+Tests.swift
+++ b/Tests/RealHTTPTests/Requests+Tests.swift
@@ -1010,6 +1010,90 @@ class RequestsTests: XCTestCase {
         XCTAssert(response.statusCode == .unauthorized, "Main call should fail with unathorized")
         XCTAssert(response.data?.asString == mainCallErrorResponse, "Failed to validate main call error")
     }
+
+    func test_retryMechanismAfterTask() async throws {
+        setupStubber(echo: true)
+        defer { stopStubber() }
+
+        var retryTaskError: Error?
+        let retryTask: (HTTPRequest) async throws -> Void = { originalRequest in
+            originalRequest.headers.set(.authBearerToken("abcdefg"))
+        }
+
+        let newClient = HTTPClient(baseURL: nil)
+        newClient.validators = [
+            CallbackValidator { response, request in
+                if request.currentRetry == 0 {
+                    return .retry(.afterTask(0, { originalRequest in
+                        try await retryTask(originalRequest)
+                    }, { error in
+                        retryTaskError = error
+                    }))
+                } else {
+                    // the next time is okay
+                    return .nextValidator
+                }
+            }
+        ]
+
+        // Setup request
+        let req = HTTPRequest {
+            $0.url = URL(string: "http://127.0.0.1:8080")!
+            $0.method = .post
+            $0.maxRetries = 3
+            $0.body = .string("doSomething")
+        }
+
+        let response = try await req.fetch(newClient)
+        let responseString = response.data?.asString
+        XCTAssert(responseString == "doSomething", "Response received after retry with alt call is wrong")
+        // should be present, set during retry
+        XCTAssertEqual(req.headers["Authorization"], "Bearer abcdefg", "Original request headers are not updated with new authorization")
+        // should be missing, because no error occurs
+        XCTAssertNil(retryTaskError, "Retry task has failed")
+    }
+
+    func test_retryMechanismAfterTaskAndFail() async throws {
+        setupStubber(echo: false)
+        defer { stopStubber() }
+
+        var retryTaskError: Error?
+        let mainCallErrorResponse = "login required"
+
+        // Network calls
+        let req = HTTPRequest {
+            $0.maxRetries = 3
+            $0.url = URL(string: "http://127.0.0.1:8080/execute")!
+        }
+
+        let newClient = HTTPClient(baseURL: nil)
+        newClient.validators = [
+            CallbackValidator { response, request in
+                return .retry(.afterTask(0, { originalRequest in
+                    throw HTTPStatusCode.internalServerError
+                }, { error in
+                    retryTaskError = error
+                }))
+            }
+        ]
+
+        // Stubber to catch /execute call
+        let stubReq = try! HTTPStubRequest().match(urlRegex: "/execute").stub(for: .get) { response in
+            response.statusCode = .unauthorized
+            response.body = mainCallErrorResponse
+        }
+        HTTPStubber.shared.add(stub: stubReq)
+
+        // Execute
+        let response = try await req.fetch(newClient)
+
+        // Check retry task result
+        XCTAssert(retryTaskError as? HTTPStatusCode == HTTPStatusCode.internalServerError, "Failed to validate retry task error")
+
+        // Check main call
+        XCTAssert(response.statusCode == .unauthorized, "Main call should fail with unathorized")
+        XCTAssert(response.data?.asString == mainCallErrorResponse, "Failed to validate main call error")
+    }
     
     func test_POSTRequestWithUnicodeParameters() async throws {
         setupStubber(echo: true)


### PR DESCRIPTION
The following PR adds a new retry strategy allowing to bridge some async work to the retry mechanism of RealHTTP.

 => `case afterTask(TimeInterval, RetryTask, RetryTaskErrorCatcher?)` retries the original call after performing an `async` work.


Currently it is only possible to provide an other `HTTPRequest` to be performed before the retry. In a case where the request Authorization is handled by something else than a HTTP service, there is no way to interface with the `Validator` to create/refresh the authorization before the retry.

By adding a strategy that allows to provide an async Task, it is possible to perform work outside RealHTTP and inject whatever the user wants into the original request. Like with the existing `retry with HTTPRequest` strategy, the error that could be triggered by the async Task is not propagated to the original request, but a callback could be provided to at least "see" it.

Two specific unit tests were also added to cover this new strategy.