### PR TITLE
HTTPAltRequestValidator all methods and properties should be marked as open to be customizable

### DIFF
--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
@@ -62,7 +62,7 @@ open class HTTPAltRequestValidator: HTTPValidator {
     // MARK: - Private Properties
     
     /// Number of executed alternate request.
-    private var numberOfAltRequestExecuted = 0
+    open var numberOfAltRequestExecuted = 0
     
     // MARK: - Initialization
     
@@ -90,7 +90,7 @@ open class HTTPAltRequestValidator: HTTPValidator {
     
     // MARK: - Protocol Conformance
     
-    public func validate(response: HTTPResponse, forRequest request: HTTPRequest) -> HTTPResponseValidatorResult {
+    open func validate(response: HTTPResponse, forRequest request: HTTPRequest) -> HTTPResponseValidatorResult {
         guard statusCodes.contains(response.statusCode) else {
             // if received status code for this request is not inside the triggerable status codes we'll skip the validator.
             return .nextValidator

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPAltRequestValidator.swift
@@ -84,7 +84,7 @@ open class HTTPAltRequestValidator: HTTPValidator {
     // MARK: - Public Functions
     
     /// Reset the state of alt requests executed.
-    public func reset() {
+    open func reset() {
         // numberOfAltRequestExecuted = 0
     }
     


### PR DESCRIPTION
The indeed of the entire class is to be `open` in order allow further customization of the behaviour,