### PR TITLE
#70: HTTP Stubbing: URL matcher incorrectly strips port when using "ignore query parameters" option 

### DIFF
--- a/Sources/RealHTTP/Client/Internal/Other Structures/Foundation+Extensions/Foundation+Extension.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/Foundation+Extensions/Foundation+Extension.swift
@@ -292,7 +292,7 @@ extension URL {
     ///
     /// NOTE: the original `host` method strip the port.
     public var fullHost: String? {
-        guard let host else { return nil }
+        guard let host = host else { return nil }
         return host + (port != nil ? ":\(port!)" : "")
     }
     

--- a/Sources/RealHTTP/Client/Internal/Other Structures/Foundation+Extensions/Foundation+Extension.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/Foundation+Extensions/Foundation+Extension.swift
@@ -262,7 +262,7 @@ extension URL {
     /// "https://www.apple.com/v1/test?param=test"
     /// would be "https://www.apple.com/v1/test"
     public var baseString: String? {
-        guard let scheme = scheme, let host = host else { return nil }
+        guard let scheme = scheme, let host = fullHost else { return nil }
         return scheme + "://" + host + path
     }
 
@@ -284,6 +284,16 @@ extension URL {
         } catch {
             return nil
         }
+    }
+    
+    // MARK: - Public Properties
+    
+    /// Return the complete host along with port (if available).
+    ///
+    /// NOTE: the original `host` method strip the port.
+    public var fullHost: String? {
+        guard let host else { return nil }
+        return host + (port != nil ? ":\(port!)" : "")
     }
     
 }

--- a/Tests/RealHTTPTests/Requests+Tests.swift
+++ b/Tests/RealHTTPTests/Requests+Tests.swift
@@ -18,6 +18,24 @@ import XCTest
 import Combine
 @testable import RealHTTP
 
+class StubberTests: XCTestCase {
+    
+    /// Test stubber along with port specified.
+    public func test_matchStubberWithExplicitPort() async throws {
+        let stub = HTTPStubRequest()
+            .match(URL: URL(string: "http://localhost:3001/some/path")!)
+            .stub(for: .get) { _, _ in
+                let response = HTTPStubResponse()
+                response.statusCode = .ok
+                return response
+            }
+        
+        let matches = stub.matchers[0].matches(request: URLRequest(url: URL(string: "http://localhost:3001/some/path")!), for: stub)
+        XCTAssertTrue(matches, "Failed to match host with port")
+    }
+    
+}
+
 class RequestsTests: XCTestCase {
     
     private var observerBag = Set<AnyCancellable>()


### PR DESCRIPTION
The following PR fixes the `HTTPStubber` with `match(URL:)` which specify both the `host` along with an explicit `port`. IN this case the `host` property of `URL` ignores the port returning only the host.  
The result is a failure in `matches()` function which, incorrectly, return `false`.

This is an example:

```swift
let stub = HTTPStubRequest()
  match(URL: URL(string: "http://localhost:3001/some/path")!)
  .stub(for: .get) { _, _ in
    let response = HTTPStubResponse()
    response.statusCode = .ok
    return response
}
        
let matches = stub.matchers[0].matches(request: URLRequest(url: URL(string: "http://localhost:3001/some/path")!), for: stub)
```

In order to fix it we added a new a new `fullHost` property in `URL` which also consider the URL.  
A test case is also added.