### PR TITLE
#75: Added weak to HTTPClient's delegate property to avoid memory leak

### DIFF
--- a/Sources/RealHTTP/Client/HTTPClient/HTTPClient.swift
+++ b/Sources/RealHTTP/Client/HTTPClient/HTTPClient.swift
@@ -28,7 +28,7 @@ public class HTTPClient {
     public static let shared = HTTPClient(baseURL: nil)
     
     /// Delegate of the client.
-    public var delegate: HTTPClientDelegate?
+    public weak var delegate: HTTPClientDelegate?
         
     /// Base URL used to compose each request.
     ///


### PR DESCRIPTION
Fixed a memory leak when setting `HTTPClient` instance's `delegate`.