### PR TITLE
#82: removed ignore condition

### DIFF
--- a/Sources/RealHTTP/Client/Internal/Other Structures/cURLHelper.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/cURLHelper.swift
@@ -143,11 +143,11 @@ public struct cURLHelper {
         let configuration = client.session.configuration
         var headers = HTTPHeaders()
         
-        for header in configuration.headers where header.name != "Cookie" {
+        for header in configuration.headers {
             headers[header.name] = header.value
         }
         
-        for header in request.headers where header.name != "Cookie" {
+        for header in request.headers {
             headers[header.name] = header.value
         }
         


### PR DESCRIPTION
Actually, we'll deliberately ignore all cookies set with the Set-Cookie header when printing the cURL description via RealHTTP. It's annoying; sometimes, it's helpful to set cookies in this manner instead of creating an NSHTTPCookie object.

In this task, we'll remove the where condition when printing header cookies.