### PR TITLE
Fix download percentage not always getting to 1 due to rounding errors

### DIFF
--- a/Sources/RealHTTP/Client/Internal/Other Structures/HTTPProgress.swift
+++ b/Sources/RealHTTP/Client/Internal/Other Structures/HTTPProgress.swift
@@ -84,8 +84,7 @@ public struct HTTPProgress: Comparable, Equatable {
         self.partialData = partialData
         
         if expectedLength != NSURLSessionTransferSizeUnknown, expectedLength != 0 {
-            let slice = Double(1.0)/Double(expectedLength)
-            self.percentage = slice*Double(currentLength)
+            self.percentage = Double(currentLength)/Double(expectedLength)
         } else {
             self.percentage = 0
         }


### PR DESCRIPTION
Sometimes download percentage does not go to '1' staying at 0.99999999999. The issue is due to rounding errors when creating: `let slice = Double(1.0)/Double(expectedLength)` in HTTPProgress constructor.