### PR TITLE
Feature/custom retry implementation

### DIFF
--- a/Documentation/3.Advanced_HTTPClient.md
+++ b/Documentation/3.Advanced_HTTPClient.md
@@ -77,6 +77,7 @@ The options are:
 - `exponential` and `fibonacci` are the same as `delayed`, but with sequentially increasing delay times
 - `after(HTTPRequest, TimeInterval, AltRequestCatcher?)` will retry the original call after calling an alternate request. For example, if you are making an authenticated request and the session has expired; you can then call a login alternate request to perform a new login and retry the original call.
 - `afterTask(TimeInterval, RetryTask, RetryTaskErrorCatcher?)` performs an async task before retrying the original request. By using an async `Task`, you may perform work outside of the scope of RealHTTP and inject whatever you need into the original request. Note that, like with the existing retry with `HTTPRequest` strategy, any error triggered by the async `Task` is not propagated to the original request. However, a callback could be provided to at least "see" it.
+- `custom` will retry the original call after the amount of seconds returned by the closure you are required to provide for this case. The closure provides you with the failed `HTTPRequest` object so you have the chance to define any custom logic based on it and return the desired amount of seconds.
 
 We'll take a closer look at these strategies below.
 

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPValidator.swift
@@ -63,6 +63,7 @@ public enum HTTPRetryStrategy {
     public typealias AltRequestCatcher = ((_ request: HTTPRequest, _ response: HTTPResponse) async throws -> Void)
     public typealias RetryTask = ((_ originalRequest: HTTPRequest) async throws -> Void)
     public typealias RetryTaskErrorCatcher = ((_ error: Error) async -> Void)
+    public typealias CustomRetryIntervalProvider = (_ request: HTTPRequest) -> TimeInterval
     
     case immediate
     case delayed(_ interval: TimeInterval)
@@ -70,6 +71,7 @@ public enum HTTPRetryStrategy {
     case fibonacci
     case after(HTTPRequest, TimeInterval, AltRequestCatcher?)
     case afterTask(TimeInterval, RetryTask, RetryTaskErrorCatcher?)
+    case custom(_ retryIntervalProvider: CustomRetryIntervalProvider)
     
     // MARK: - Internal Functions
     
@@ -108,6 +110,9 @@ public enum HTTPRetryStrategy {
 
         case .afterTask:
             return 0
+
+        case .custom(let retryIntervalProvider):
+            return retryIntervalProvider(request)
         }
     }
     

--- a/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPValidator.swift
+++ b/Sources/RealHTTP/Client/Internal/HTTPResponseValidator/HTTPValidator.swift
@@ -59,6 +59,8 @@ public enum HTTPResponseValidatorResult {
 ///              - the request you want to execute before retry the original request.
 ///              - the amount of time before retry the original request once you got the response for the alt request.
 ///              - an optional async callback to execute once you got the response of the alt request before retry the original request.
+/// - `custom` will retry the original call after the amount of seconds returned by the closure you are required to provide for this case.
+///            The closure provides you with the failed `HTTPRequest` object so you have the chance to define any custom logic based on it and return the desired amount of seconds.
 public enum HTTPRetryStrategy {
     public typealias AltRequestCatcher = ((_ request: HTTPRequest, _ response: HTTPResponse) async throws -> Void)
     public typealias RetryTask = ((_ originalRequest: HTTPRequest) async throws -> Void)


### PR DESCRIPTION
Hello,

this PR should add the feature requested in #79.

You can provide a custom retry strategy by implementing a closure that takes the current `HTTPRequest` as input and returns an amount of seconds of your choice.

For example, the requested `.exponential(base: 2, from: 1)` could be easily implemented in this way:
```swift
let strategy: HTTPRetryStrategy = .custom { request in
    let numberOfPreviousAttempts = request.currentRetry
    let maximumNumberOfAttempts = request.maxRetries
            
    guard numberOfPreviousAttempts < maximumNumberOfAttempts else { return 0 }
    return pow(Double(2), Double(numberOfPreviousAttempts + 1))
}
```